### PR TITLE
feat: add audio player component

### DIFF
--- a/components/audio-player.tsx
+++ b/components/audio-player.tsx
@@ -1,0 +1,72 @@
+"use client"
+
+import * as React from 'react'
+
+import type { BinauralTrack } from '@/lib/audio-engine'
+import type { UseBinauralBeatsResult } from '@/hooks/useBinauralBeats'
+import { Button } from '@/components/ui/button'
+import { Select } from '@/components/ui/select'
+
+interface AudioPlayerProps extends Pick<UseBinauralBeatsResult, 'currentTrack' | 'isPlaying' | 'toggle'> {
+  tracks: ReadonlyArray<BinauralTrack>
+  engineReady?: boolean
+}
+
+export function AudioPlayer({
+  tracks,
+  currentTrack,
+  isPlaying,
+  toggle,
+  engineReady = true,
+}: AudioPlayerProps): React.ReactElement {
+  const [trackName, setTrackName] = React.useState<string>(currentTrack ?? '')
+
+  const handleChange = (event: React.ChangeEvent<HTMLSelectElement>): void => {
+    setTrackName(event.target.value)
+  }
+
+  const handleToggle = (): void => {
+    if (trackName === '' || !engineReady) {
+      return
+    }
+    toggle(trackName)
+  }
+
+  const isCurrentTrack = isPlaying && currentTrack === trackName
+  const controlsDisabled = !engineReady || trackName === ''
+
+  return (
+    <div className="flex flex-col items-start gap-3 sm:flex-row sm:items-center">
+      <Select
+        aria-label="Binaural track"
+        value={trackName}
+        onChange={handleChange}
+        disabled={!engineReady}
+        className="sm:w-48"
+      >
+        <option value="" disabled>
+          Select track
+        </option>
+        {tracks.map((track) => {
+          const name = track?.name ?? ''
+          if (name === '') {
+            return null
+          }
+          return (
+            <option key={name} value={name}>
+              {name}
+            </option>
+          )
+        })}
+      </Select>
+      <Button
+        type="button"
+        aria-label={isCurrentTrack ? 'Pause track' : 'Play track'}
+        onClick={handleToggle}
+        disabled={controlsDisabled}
+      >
+        {isCurrentTrack ? 'Pause' : 'Play'}
+      </Button>
+    </div>
+  )
+}

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react'
+
+import { cn } from '@/lib/utils'
+
+function Select({ className, children, ...props }: React.ComponentProps<'select'>): React.ReactElement {
+  return (
+    <select
+      data-slot="select"
+      className={cn(
+        'placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+        'focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]',
+        'aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive',
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </select>
+  )
+}
+
+export { Select }


### PR DESCRIPTION
## Summary
- add Select UI primitive for styled HTML select elements
- add AudioPlayer component with track selector and play/pause toggle

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68c8187290008330a6ca4784baf0be30