### PR TITLE
Integrate binaural beats audio player into Pomodoro app

### DIFF
--- a/components/theme-provider.tsx
+++ b/components/theme-provider.tsx
@@ -6,6 +6,16 @@ import {
   type ThemeProviderProps,
 } from 'next-themes'
 
-export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
+interface ExtendedThemeProviderProps extends ThemeProviderProps {
+  /**
+   * Child nodes that will receive theme context.
+   */
+  children: React.ReactNode
+}
+
+export function ThemeProvider({
+  children,
+  ...props
+}: ExtendedThemeProviderProps): JSX.Element {
   return <NextThemesProvider {...props}>{children}</NextThemesProvider>
 }

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -35,25 +35,33 @@ const buttonVariants = cva(
   },
 )
 
-function Button({
-  className,
-  variant,
-  size,
-  asChild = false,
-  ...props
-}: React.ComponentProps<'button'> &
-  VariantProps<typeof buttonVariants> & {
-    asChild?: boolean
-  }) {
-  const Comp = asChild ? Slot : 'button'
-
-  return (
-    <Comp
-      data-slot="button"
-      className={cn(buttonVariants({ variant, size, className }))}
-      {...props}
-    />
-  )
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  /**
+   * Render the button as a child of another element using Radix Slot.
+   */
+  asChild?: boolean
 }
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  (
+    { className, variant, size, asChild = false, ...props },
+    ref,
+  ): JSX.Element => {
+    const Comp = asChild ? Slot : 'button'
+
+    return (
+      <Comp
+        ref={ref}
+        data-slot="button"
+        className={cn(buttonVariants({ variant, size, className }))}
+        {...props}
+      />
+    )
+  },
+)
+
+Button.displayName = 'Button'
 
 export { Button, buttonVariants }


### PR DESCRIPTION
## Summary
- add AudioPlayer and binaural beats hook
- render player with track controls under timer buttons
- tighten type safety for timer updates and session indicators
- fix TypeScript errors in theme provider and button components

## Testing
- `npm run lint` *(fails: prompts for ESLint config)*
- `npx tsc --noEmit` *(passes)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c81b99d6388330b7bd23678b47ff02