### PR TITLE
Integrate task list with pomodoro timer

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useEffect, useRef } from "react"
+import { useState, useEffect, useRef, useMemo, useCallback } from "react"
 import { Button } from "@/components/ui/button"
 import { Play, Pause, RotateCcw, Settings } from "lucide-react"
 import { DynamicBackground } from "@/components/dynamic-background"
@@ -11,6 +11,8 @@ import { IntroductionPopup } from "@/components/introduction-popup"
 import { useBinauralBeats } from "@/hooks/useBinauralBeats"
 import { Volume2, VolumeX, ChevronLeft, ChevronRight } from "lucide-react"
 import { TRACKS } from "@/lib/audio-engine"
+import { TaskList } from "@/components/task-list"
+import { useTaskList, type Task, type TaskInput } from "@/hooks/useTaskList"
 
 export default function PomodoroApp() {
   const [timeLeft, setTimeLeft] = useState(25 * 60) // 25 minutes in seconds
@@ -25,6 +27,9 @@ export default function PomodoroApp() {
     sessionsUntilLongBreak: 4,
   })
   const [currentSession, setCurrentSession] = useState(1)
+  const { tasks, addTask, deleteTask, toggleTaskComplete, incrementPomodoros, getTaskById } = useTaskList()
+  const [activeTaskId, setActiveTaskId] = useState<string | null>(null)
+  const [taskWarning, setTaskWarning] = useState<string | null>(null)
   const intervalRef = useRef<NodeJS.Timeout | null>(null)
   const { currentTrack, isPlaying, toggle, muted, setMuted, play, pause } = useBinauralBeats()
   const [selectedIndex, setSelectedIndex] = useState<number>(() => {
@@ -32,7 +37,15 @@ export default function PomodoroApp() {
     return idx >= 0 ? idx : 0
   })
   const selectedTrack: string = TRACKS[selectedIndex]?.name ?? "Alpha"
+  const activeTask = useMemo<Task | null>(() => (activeTaskId ? getTaskById(activeTaskId) : null), [activeTaskId, getTaskById])
+  const remainingPomodoros: number | null = activeTask
+    ? Math.max(activeTask.pomodorosRequired - activeTask.pomodorosCompleted, 0)
+    : null
   const isClient: boolean = typeof window !== "undefined"
+  const deriveDefaultActiveTaskId = useCallback((): string | null => {
+    const firstIncomplete = tasks.find(task => !task.isCompleted)
+    return firstIncomplete?.id ?? null
+  }, [tasks])
 
   // Show introduction popup on first visit
   useEffect(() => {
@@ -45,11 +58,51 @@ export default function PomodoroApp() {
   }, [isClient])
 
   useEffect(() => {
+    if (tasks.length === 0) {
+      setActiveTaskId(null)
+      return
+    }
+
+    setActiveTaskId((previous: string | null): string | null => {
+      if (!previous) {
+        return deriveDefaultActiveTaskId()
+      }
+
+      const existingTask = tasks.find((task: Task): boolean => task.id === previous)
+      if (!existingTask) {
+        return deriveDefaultActiveTaskId()
+      }
+
+      if (existingTask.isCompleted) {
+        const nextIncomplete = tasks.find((task: Task): boolean => !task.isCompleted && task.id !== existingTask.id)
+        return nextIncomplete?.id ?? null
+      }
+
+      return previous
+    })
+  }, [tasks, deriveDefaultActiveTaskId])
+
+  useEffect(() => {
+    if (!taskWarning || !isClient) {
+      return
+    }
+
+    const timeout = window.setTimeout(() => {
+      setTaskWarning(null)
+    }, 2500)
+
+    return () => {
+      window.clearTimeout(timeout)
+    }
+  }, [taskWarning, isClient])
+
+  useEffect(() => {
     if (isActive && timeLeft > 0) {
       intervalRef.current = setInterval(() => {
         setTimeLeft((time: number): number => time - 1)
       }, 1000)
     } else if (timeLeft === 0) {
+      const completedFocusSession = !isBreak
       // Timer finished - play notification sound
       const audio = new Audio(
         "data:audio/wav;base64,UklGRnoGAABXQVZFZm10IBAAAAABAAEAQB8AAEAfAAABAAgAZGF0YQoGAACBhYqFbF1fdJivrJBhNjVgodDbq2EcBj+a2/LDciUFLIHO8tiJNwgZaLvt559NEAxQp+PwtmMcBjiR1/LMeSwFJHfH8N2QQAoUXrTp66hVFApGn+DyvmwhBTuR2O/JdSYELIHO8tiJNwgZaLvt559NEAxQp+PwtmMcBjiR1/LMeSwFJHfH8N2QQAoUXrTp66hVFApGn+DyvmwhBTuR2O/JdSYELIHO8tiJNwgZaLvt559NEAxQp+PwtmMcBjiR1/LMeSwFJHfH8N2QQAoUXrTp66hVFApGn+DyvmwhBTuR2O/JdSYE",
@@ -58,6 +111,20 @@ export default function PomodoroApp() {
       audio.play().catch(() => {}) // Ignore errors if audio can't play
 
       setIsActive(false)
+      if (completedFocusSession && activeTaskId) {
+        const updatedTask = incrementPomodoros(activeTaskId)
+        if (!updatedTask) {
+          setActiveTaskId(null)
+        } else {
+          const goalReached = updatedTask.pomodorosCompleted >= updatedTask.pomodorosRequired
+          if (goalReached && !updatedTask.isCompleted) {
+            const completedTask = toggleTaskComplete(updatedTask.id)
+            if (completedTask?.id === activeTaskId) {
+              setActiveTaskId(null)
+            }
+          }
+        }
+      }
       if (isBreak) {
         setIsBreak(false)
         setTimeLeft(settings.workTime * 60)
@@ -78,10 +145,35 @@ export default function PomodoroApp() {
         clearInterval(intervalRef.current)
       }
     }
-  }, [isActive, timeLeft, isBreak, settings, currentSession])
+  }, [isActive, timeLeft, isBreak, settings, currentSession, activeTaskId, incrementPomodoros, toggleTaskComplete])
 
-  const toggleTimer = () => {
+  useEffect(() => {
+    if (!isActive) {
+      return
+    }
+
+    if (!activeTask || activeTask.isCompleted) {
+      setIsActive(false)
+      pause()
+      setTaskWarning(previous => previous ?? "Select an incomplete task to continue.")
+    }
+  }, [activeTask, isActive, pause])
+
+  const toggleTimer = (): void => {
     const next = !isActive
+    if (next) {
+      const targetTask = activeTaskId ? getTaskById(activeTaskId) : null
+      if (!targetTask) {
+        setTaskWarning("Please select a task before starting the timer.")
+        return
+      }
+      if (targetTask.isCompleted) {
+        setTaskWarning("The selected task is already complete. Choose another task to start focusing.")
+        return
+      }
+    }
+
+    setTaskWarning(null)
     setIsActive(next)
     // Tie audio playback to timer control
     if (next) {
@@ -91,12 +183,68 @@ export default function PomodoroApp() {
     }
   }
 
-  const resetTimer = () => {
+  const resetTimer = (): void => {
     setIsActive(false)
     setIsBreak(false)
     setTimeLeft(settings.workTime * 60)
     setCurrentSession(1)
+    setTaskWarning(null)
   }
+
+  const handleSelectTask = useCallback((taskId: string): void => {
+    const selectedTask = getTaskById(taskId)
+    if (!selectedTask) {
+      setActiveTaskId(null)
+      return
+    }
+
+    setActiveTaskId(selectedTask.id)
+    setTaskWarning(null)
+  }, [getTaskById])
+
+  const handleAddTask = useCallback(
+    (input: TaskInput): Task | null => {
+      const createdTask = addTask(input)
+      if (!createdTask) {
+        return null
+      }
+
+      setTaskWarning(null)
+      setActiveTaskId(previous => previous ?? createdTask.id)
+      return createdTask
+    },
+    [addTask],
+  )
+
+  const handleToggleTaskComplete = useCallback(
+    (taskId: string): Task | null => {
+      const updatedTask = toggleTaskComplete(taskId)
+      if (!updatedTask) {
+        return null
+      }
+
+      if (updatedTask.isCompleted) {
+        setActiveTaskId(previous => (previous === taskId ? null : previous))
+      } else {
+        setActiveTaskId(updatedTask.id)
+      }
+      setTaskWarning(null)
+      return updatedTask
+    },
+    [toggleTaskComplete],
+  )
+
+  const handleDeleteTask = useCallback(
+    (taskId: string): Task | null => {
+      const removedTask = deleteTask(taskId)
+      if (removedTask) {
+        setActiveTaskId(previous => (previous === taskId ? null : previous))
+        setTaskWarning(null)
+      }
+      return removedTask
+    },
+    [deleteTask],
+  )
 
   const handleCloseIntroduction = () => {
     setShowIntroduction(false)
@@ -121,127 +269,156 @@ export default function PomodoroApp() {
       </div>
 
       <div className="relative z-10 min-h-screen flex items-center justify-center p-3">
-        <div className="p-6 rounded-2xl max-w-sm w-full bg-transparent">
-          <div className="text-center space-y-6">
-            {/* Timer Circle */}
-            <div className="relative flex items-center justify-center">
-              <CircularProgress progress={progress} size={240} strokeWidth={6} isActive={isActive} />
-              <div className="absolute inset-0 flex items-center justify-center">
-                <TimerDisplay
-                  timeLeft={timeLeft}
-                  isActive={isActive}
-                  title={isBreak ? "Break Time" : "Focus"}
-                  subtitle={
-                    <div className="flex justify-center gap-2" role="progressbar" aria-label="Session progress">
-                      {Array.from(
-                        { length: settings.sessionsUntilLongBreak },
-                        (_: unknown, i: number) => (
-                          <div
-                            key={i}
-                            className={`w-2.5 h-2.5 rounded-full transition-all duration-300 ${
-                              i < currentSession - 1
-                                ? "bg-white/80 shadow-sm scale-110"
-                                : i === currentSession - 1 && !isBreak
-                                  ? "bg-white/80 animate-pulse shadow-sm scale-110"
-                                  : "bg-white/20"
-                            }`}
-                          />
-                        ),
-                      )}
-                    </div>
-                  }
-                />
-              </div>
-            </div>
-
-            {/* Controls */}
-            <div className="flex flex-col items-center gap-3">
-              <div className="flex items-center justify-center gap-3">
-                <Button
-                  onClick={toggleTimer}
-                  size="default"
-                  className="bg-white/10 hover:bg-white/20 text-white rounded-full w-14 h-14 p-0 backdrop-blur-sm border border-white/20 shadow-lg hover:shadow-xl transition-all duration-300"
-                  aria-label={isActive ? "Pause timer" : "Start timer"}
-                >
-                  {isActive ? <Pause className="w-5 h-5" /> : <Play className="w-5 h-5" />}
-                </Button>
-
-                <Button
-                  onClick={resetTimer}
-                  variant="outline"
-                  size="default"
-                  className="rounded-full w-10 h-10 p-0 bg-white/5 hover:bg-white/10 backdrop-blur-sm border-white/20 text-white hover:text-white transition-all duration-300"
-                  aria-label="Reset timer"
-                >
-                  <RotateCcw className="w-4 h-4" />
-                </Button>
-
-                <Button
-                  onClick={() => setShowSettings(true)}
-                  variant="outline"
-                  size="default"
-                  className="rounded-full w-10 h-10 p-0 bg-white/5 hover:bg-white/10 backdrop-blur-sm border-white/20 text-white hover:text-white transition-all duration-300"
-                  aria-label="Open settings"
-                >
-                  <Settings className="w-4 h-4" />
-                </Button>
-              </div>
-              <div className="inline-flex items-stretch text-white border border-white/20 rounded-md bg-black/20 backdrop-blur-sm shadow-md overflow-hidden">
-                <button
-                  type="button"
-                  className="px-2 h-9 flex items-center hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/30 disabled:opacity-50"
-                  aria-label="Previous track"
-                  onClick={() => {
-                    const prev = selectedIndex <= 0 ? TRACKS.length - 1 : selectedIndex - 1
-                    const name = TRACKS[prev]?.name ?? selectedTrack
-                    setSelectedIndex(prev)
-                    if (isClient && isPlaying) {
-                      void toggle(name).catch(() => {})
+        <div className="flex flex-col xl:flex-row items-start justify-center gap-6 w-full max-w-5xl">
+          <div className="p-6 rounded-2xl max-w-sm w-full bg-transparent">
+            <div className="text-center space-y-6">
+              {/* Timer Circle */}
+              <div className="relative flex items-center justify-center">
+                <CircularProgress progress={progress} size={240} strokeWidth={6} isActive={isActive} />
+                <div className="absolute inset-0 flex items-center justify-center">
+                  <TimerDisplay
+                    timeLeft={timeLeft}
+                    isActive={isActive}
+                    title={isBreak ? "Break Time" : "Focus"}
+                    subtitle={
+                      <div className="space-y-1.5">
+                        <div className="flex justify-center gap-2" role="progressbar" aria-label="Session progress">
+                          {Array.from(
+                            { length: settings.sessionsUntilLongBreak },
+                            (_: unknown, i: number) => (
+                              <div
+                                key={i}
+                                className={`w-2.5 h-2.5 rounded-full transition-all duration-300 ${
+                                  i < currentSession - 1
+                                    ? "bg-white/80 shadow-sm scale-110"
+                                    : i === currentSession - 1 && !isBreak
+                                      ? "bg-white/80 animate-pulse shadow-sm scale-110"
+                                      : "bg-white/20"
+                                }`}
+                              />
+                            ),
+                          )}
+                        </div>
+                        {activeTask ? (
+                          <div className="space-y-0.5">
+                            <p className="text-xs text-white/80">
+                              Working on: <span className="font-semibold text-white">{activeTask.title}</span>
+                            </p>
+                            <p className="text-[0.65rem] text-white/60">
+                              {remainingPomodoros ?? 0} pomodoro{remainingPomodoros === 1 ? "" : "s"} remaining (
+                              {activeTask.pomodorosCompleted}/{activeTask.pomodorosRequired} complete)
+                            </p>
+                          </div>
+                        ) : (
+                          <p className="text-xs text-white/70">Select a task to track your focus.</p>
+                        )}
+                      </div>
                     }
-                  }}
-                  disabled={TRACKS.length === 0}
-                >
-                  <ChevronLeft className="w-4 h-4" />
-                </button>
-
-                <div
-                  role="status"
-                  aria-live="polite"
-                  className="px-3 py-2 h-9 flex items-center justify-center min-w-[140px] text-center"
-                >
-                  {selectedTrack}
+                  />
                 </div>
+              </div>
 
-                <button
-                  type="button"
-                  className="px-2 h-9 flex items-center hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/30 disabled:opacity-50"
-                  aria-label="Next track"
-                  onClick={() => {
-                    const next = selectedIndex < 0 || selectedIndex >= TRACKS.length - 1 ? 0 : selectedIndex + 1
-                    const name = TRACKS[next]?.name ?? selectedTrack
-                    setSelectedIndex(next)
-                    if (isClient && isPlaying) {
-                      void toggle(name).catch(() => {})
-                    }
-                  }}
-                  disabled={TRACKS.length === 0}
-                >
-                  <ChevronRight className="w-4 h-4" />
-                </button>
+              {/* Controls */}
+              <div className="flex flex-col items-center gap-4">
+                <div className="flex items-center justify-center gap-3">
+                  <Button
+                    onClick={toggleTimer}
+                    size="default"
+                    className="bg-white/10 hover:bg-white/20 text-white rounded-full w-14 h-14 p-0 backdrop-blur-sm border border-white/20 shadow-lg hover:shadow-xl transition-all duration-300"
+                    aria-label={isActive ? "Pause timer" : "Start timer"}
+                  >
+                    {isActive ? <Pause className="w-5 h-5" /> : <Play className="w-5 h-5" />}
+                  </Button>
 
-                <button
-                  type="button"
-                  className="px-2 h-9 flex items-center hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/30"
-                  aria-label={muted ? "Unmute audio" : "Mute audio"}
-                  onClick={() => setMuted(!muted)}
-                >
-                  {muted ? <VolumeX className="w-4 h-4" /> : <Volume2 className="w-4 h-4" />}
-                </button>
+                  <Button
+                    onClick={resetTimer}
+                    variant="outline"
+                    size="default"
+                    className="rounded-full w-10 h-10 p-0 bg-white/5 hover:bg-white/10 backdrop-blur-sm border-white/20 text-white hover:text-white transition-all duration-300"
+                    aria-label="Reset timer"
+                  >
+                    <RotateCcw className="w-4 h-4" />
+                  </Button>
+
+                  <Button
+                    onClick={() => setShowSettings(true)}
+                    variant="outline"
+                    size="default"
+                    className="rounded-full w-10 h-10 p-0 bg-white/5 hover:bg-white/10 backdrop-blur-sm border-white/20 text-white hover:text-white transition-all duration-300"
+                    aria-label="Open settings"
+                  >
+                    <Settings className="w-4 h-4" />
+                  </Button>
+                </div>
+                <div className="inline-flex items-stretch text-white border border-white/20 rounded-md bg-black/20 backdrop-blur-sm shadow-md overflow-hidden">
+                  <button
+                    type="button"
+                    className="px-2 h-9 flex items-center hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/30 disabled:opacity-50"
+                    aria-label="Previous track"
+                    onClick={() => {
+                      const prev = selectedIndex <= 0 ? TRACKS.length - 1 : selectedIndex - 1
+                      const name = TRACKS[prev]?.name ?? selectedTrack
+                      setSelectedIndex(prev)
+                      if (isClient && isPlaying) {
+                        void toggle(name).catch(() => {})
+                      }
+                    }}
+                    disabled={TRACKS.length === 0}
+                  >
+                    <ChevronLeft className="w-4 h-4" />
+                  </button>
+
+                  <div
+                    role="status"
+                    aria-live="polite"
+                    className="px-3 py-2 h-9 flex items-center justify-center min-w-[140px] text-center"
+                  >
+                    {selectedTrack}
+                  </div>
+
+                  <button
+                    type="button"
+                    className="px-2 h-9 flex items-center hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/30 disabled:opacity-50"
+                    aria-label="Next track"
+                    onClick={() => {
+                      const next = selectedIndex < 0 || selectedIndex >= TRACKS.length - 1 ? 0 : selectedIndex + 1
+                      const name = TRACKS[next]?.name ?? selectedTrack
+                      setSelectedIndex(next)
+                      if (isClient && isPlaying) {
+                        void toggle(name).catch(() => {})
+                      }
+                    }}
+                    disabled={TRACKS.length === 0}
+                  >
+                    <ChevronRight className="w-4 h-4" />
+                  </button>
+
+                  <button
+                    type="button"
+                    className="px-2 h-9 flex items-center hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/30"
+                    aria-label={muted ? "Unmute audio" : "Mute audio"}
+                    onClick={() => setMuted(!muted)}
+                  >
+                    {muted ? <VolumeX className="w-4 h-4" /> : <Volume2 className="w-4 h-4" />}
+                  </button>
+                </div>
+                {taskWarning ? (
+                  <p className="text-xs text-amber-200/90 text-center" role="status" aria-live="polite">
+                    {taskWarning}
+                  </p>
+                ) : null}
               </div>
             </div>
-
-            
           </div>
+
+          <TaskList
+            tasks={tasks}
+            activeTaskId={activeTaskId}
+            onSelectTask={handleSelectTask}
+            onAddTask={handleAddTask}
+            onToggleTaskComplete={handleToggleTaskComplete}
+            onDeleteTask={handleDeleteTask}
+          />
         </div>
       </div>
 

--- a/components/task-list.tsx
+++ b/components/task-list.tsx
@@ -1,0 +1,183 @@
+"use client"
+
+import { useMemo, useState, type ChangeEvent, type FormEvent } from "react"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { cn } from "@/lib/utils"
+import type { Task, TaskInput } from "@/hooks/useTaskList"
+
+interface TaskListProps {
+  tasks: Task[]
+  activeTaskId: string | null
+  onSelectTask: (taskId: string) => void
+  onAddTask: (input: TaskInput) => Task | null
+  onToggleTaskComplete: (taskId: string) => Task | null
+  onDeleteTask: (taskId: string) => Task | null
+}
+
+export function TaskList({
+  tasks,
+  activeTaskId,
+  onSelectTask,
+  onAddTask,
+  onToggleTaskComplete,
+  onDeleteTask,
+}: TaskListProps): JSX.Element {
+  const [newTaskTitle, setNewTaskTitle] = useState<string>("")
+  const [pomodoroCount, setPomodoroCount] = useState<number>(1)
+  const [formMessage, setFormMessage] = useState<string | null>(null)
+
+  const incompleteTaskCount = useMemo<number>(() => tasks.filter((task: Task): boolean => !task.isCompleted).length, [tasks])
+
+  const handleAddTask = (event: FormEvent<HTMLFormElement>): void => {
+    event.preventDefault()
+    const trimmedTitle = newTaskTitle.trim()
+    if (trimmedTitle.length === 0) {
+      setFormMessage("Please enter a task name.")
+      return
+    }
+
+    const sanitizedCount = Number.isFinite(pomodoroCount) ? Math.max(1, Math.round(pomodoroCount)) : 1
+    const createdTask = onAddTask({ title: trimmedTitle, pomodorosRequired: sanitizedCount })
+
+    if (!createdTask) {
+      setFormMessage("Unable to add task. Please try again.")
+      return
+    }
+
+    setFormMessage(null)
+    setNewTaskTitle("")
+    setPomodoroCount(1)
+  }
+
+  const handlePomodoroInput = (event: ChangeEvent<HTMLInputElement>): void => {
+    const value = Number.parseInt(event.target.value, 10)
+    if (Number.isNaN(value)) {
+      setPomodoroCount(1)
+      return
+    }
+    setPomodoroCount(Math.max(1, value))
+  }
+
+  const handleTitleChange = (event: ChangeEvent<HTMLInputElement>): void => {
+    setNewTaskTitle(event.target.value)
+  }
+
+  const handleSelectTask = (taskId: string): void => {
+    onSelectTask(taskId)
+    setFormMessage(null)
+  }
+
+  return (
+    <div className="w-full max-w-md text-white bg-black/40 border border-white/10 rounded-2xl p-4 backdrop-blur-lg shadow-xl">
+      <div className="flex items-center justify-between mb-4">
+        <div>
+          <h2 className="text-lg font-semibold">Tasks</h2>
+          <p className="text-xs text-white/60">{incompleteTaskCount} task{incompleteTaskCount === 1 ? "" : "s"} remaining</p>
+        </div>
+      </div>
+
+      <form onSubmit={handleAddTask} className="space-y-3 mb-5" noValidate>
+        <div className="space-y-2">
+          <label className="text-xs font-medium uppercase tracking-wide text-white/70" htmlFor="task-title">
+            Task name
+          </label>
+          <Input
+            id="task-title"
+            value={newTaskTitle}
+            onChange={handleTitleChange}
+            placeholder="Write article outline"
+            className="bg-white/5 border-white/20 text-white placeholder:text-white/40"
+            required
+          />
+        </div>
+        <div className="space-y-2">
+          <label className="text-xs font-medium uppercase tracking-wide text-white/70" htmlFor="task-pomodoros">
+            Pomodoros needed
+          </label>
+          <Input
+            id="task-pomodoros"
+            type="number"
+            min={1}
+            value={pomodoroCount}
+            onChange={handlePomodoroInput}
+            className="bg-white/5 border-white/20 text-white"
+            required
+          />
+        </div>
+        <Button type="submit" className="w-full bg-white/20 hover:bg-white/30 text-white">
+          Add task
+        </Button>
+        {formMessage ? (
+          <p className="text-xs text-amber-200/90" role="status" aria-live="polite">
+            {formMessage}
+          </p>
+        ) : null}
+      </form>
+
+      <div className="space-y-3" role="list">
+        {tasks.length === 0 ? (
+          <p className="text-sm text-white/60">No tasks yet. Add one to get started.</p>
+        ) : (
+          tasks.map((task: Task) => {
+            const isActive = task.id === activeTaskId
+            const pomodorosRemaining = Math.max(task.pomodorosRequired - task.pomodorosCompleted, 0)
+            return (
+              <div
+                key={task.id}
+                className={cn(
+                  "border border-white/10 rounded-xl p-3 transition-all duration-200 backdrop-blur-sm bg-white/5",
+                  isActive ? "ring-2 ring-white/60 shadow-lg" : "",
+                  task.isCompleted ? "opacity-70" : "",
+                )}
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <button
+                    type="button"
+                    onClick={() => handleSelectTask(task.id)}
+                    className="text-left flex-1"
+                    aria-pressed={isActive}
+                  >
+                    <p
+                      className={cn(
+                        "text-sm font-medium",
+                        task.isCompleted ? "line-through text-white/60" : "text-white",
+                        isActive ? "drop-shadow" : "",
+                      )}
+                    >
+                      {task.title}
+                    </p>
+                    <p className="text-xs text-white/60">
+                      {task.pomodorosCompleted} / {task.pomodorosRequired} pomodoro{task.pomodorosRequired === 1 ? "" : "s"}
+                    </p>
+                    <p className="text-[0.65rem] text-white/50">{pomodorosRemaining} remaining</p>
+                  </button>
+                  <div className="flex flex-col gap-2">
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      className="bg-white/10 border-white/20 text-white hover:bg-white/20"
+                      onClick={() => onToggleTaskComplete(task.id)}
+                    >
+                      {task.isCompleted ? "Reopen" : "Done"}
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      className="bg-white/5 hover:bg-white/15 text-white"
+                      onClick={() => onDeleteTask(task.id)}
+                    >
+                      Remove
+                    </Button>
+                  </div>
+                </div>
+              </div>
+            )
+          })
+        )}
+      </div>
+    </div>
+  )
+}

--- a/hooks/useTaskList.ts
+++ b/hooks/useTaskList.ts
@@ -1,0 +1,195 @@
+import { useCallback, useEffect, useState } from "react"
+
+export interface Task {
+  id: string
+  title: string
+  pomodorosRequired: number
+  pomodorosCompleted: number
+  isCompleted: boolean
+}
+
+export interface TaskInput {
+  title: string
+  pomodorosRequired: number
+}
+
+export interface UseTaskListResult {
+  tasks: Task[]
+  addTask: (task: TaskInput) => Task | null
+  deleteTask: (taskId: string) => Task | null
+  toggleTaskComplete: (taskId: string) => Task | null
+  incrementPomodoros: (taskId: string) => Task | null
+  getTaskById: (taskId: string) => Task | null
+}
+
+const STORAGE_KEY = "pomopulse.tasks"
+
+const isTask = (value: unknown): value is Task => {
+  if (typeof value !== "object" || value === null) {
+    return false
+  }
+
+  const maybeTask = value as Partial<Task>
+  return (
+    typeof maybeTask.id === "string" &&
+    typeof maybeTask.title === "string" &&
+    typeof maybeTask.pomodorosRequired === "number" &&
+    typeof maybeTask.pomodorosCompleted === "number" &&
+    typeof maybeTask.isCompleted === "boolean"
+  )
+}
+
+const createId = (): string => {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID()
+  }
+  return `task-${Date.now()}-${Math.random().toString(16).slice(2)}`
+}
+
+const parseStoredTasks = (rawValue: unknown): Task[] => {
+  if (typeof rawValue !== "string") {
+    return []
+  }
+
+  try {
+    const parsed = JSON.parse(rawValue) as unknown
+    if (!Array.isArray(parsed)) {
+      return []
+    }
+
+    return parsed
+      .filter(isTask)
+      .map((task: Task): Task => ({
+        ...task,
+        pomodorosRequired: Math.max(1, Math.round(task.pomodorosRequired)),
+        pomodorosCompleted: Math.max(0, Math.min(Math.round(task.pomodorosCompleted), Math.max(1, Math.round(task.pomodorosRequired)))),
+      }))
+  } catch (error) {
+    console.error("Failed to parse stored tasks", error)
+    return []
+  }
+}
+
+export function useTaskList(): UseTaskListResult {
+  const [tasks, setTasks] = useState<Task[]>([])
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return
+    }
+
+    const stored = window.localStorage.getItem(STORAGE_KEY)
+    if (!stored) {
+      return
+    }
+
+    const parsedTasks = parseStoredTasks(stored)
+    if (parsedTasks.length > 0) {
+      setTasks(parsedTasks)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return
+    }
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(tasks))
+  }, [tasks])
+
+  const addTask = useCallback((task: TaskInput): Task | null => {
+    const trimmedTitle = task.title.trim()
+    if (trimmedTitle.length === 0) {
+      return null
+    }
+
+    const required = Number.isFinite(task.pomodorosRequired)
+      ? Math.max(1, Math.round(task.pomodorosRequired))
+      : 1
+
+    const newTask: Task = {
+      id: createId(),
+      title: trimmedTitle,
+      pomodorosRequired: required,
+      pomodorosCompleted: 0,
+      isCompleted: false,
+    }
+
+    setTasks((previous: Task[]): Task[] => [...previous, newTask])
+    return newTask
+  }, [])
+
+  const deleteTask = useCallback((taskId: string): Task | null => {
+    let removedTask: Task | null = null
+    setTasks((previous: Task[]): Task[] => {
+      const nextTasks = previous.filter((task: Task): boolean => {
+        if (task.id === taskId) {
+          removedTask = task
+          return false
+        }
+        return true
+      })
+      return nextTasks
+    })
+    return removedTask
+  }, [])
+
+  const toggleTaskComplete = useCallback((taskId: string): Task | null => {
+    let updatedTask: Task | null = null
+    setTasks((previous: Task[]): Task[] =>
+      previous.map((task: Task): Task => {
+        if (task.id !== taskId) {
+          return task
+        }
+        const isCompleted = !task.isCompleted
+        const pomodorosCompleted = isCompleted
+          ? task.pomodorosRequired
+          : Math.min(task.pomodorosCompleted, task.pomodorosRequired)
+
+        updatedTask = {
+          ...task,
+          isCompleted,
+          pomodorosCompleted,
+        }
+        return updatedTask
+      }),
+    )
+    return updatedTask
+  }, [])
+
+  const incrementPomodoros = useCallback((taskId: string): Task | null => {
+    let updatedTask: Task | null = null
+    setTasks((previous: Task[]): Task[] =>
+      previous.map((task: Task): Task => {
+        if (task.id !== taskId) {
+          return task
+        }
+
+        if (task.pomodorosCompleted >= task.pomodorosRequired) {
+          updatedTask = task
+          return task
+        }
+
+        updatedTask = {
+          ...task,
+          pomodorosCompleted: Math.min(task.pomodorosRequired, task.pomodorosCompleted + 1),
+        }
+        return updatedTask
+      }),
+    )
+    return updatedTask
+  }, [])
+
+  const getTaskById = useCallback(
+    (taskId: string): Task | null => tasks.find((task: Task): boolean => task.id === taskId) ?? null,
+    [tasks],
+  )
+
+  return {
+    tasks,
+    addTask,
+    deleteTask,
+    toggleTaskComplete,
+    incrementPomodoros,
+    getTaskById,
+  }
+}


### PR DESCRIPTION
## Summary
- add a reusable useTaskList hook to manage persistent pomodoro tasks with safe operations
- introduce a TaskList panel that lets users add, select, complete, and remove focus tasks with pomodoro progress
- connect the pomodoro timer to task state, preventing starts without an active task and updating task progress on session completion while surfacing helpful status messaging

## Testing
- npx tsc --noEmit
- npm run lint *(fails: prompts for initial ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68d3e3c8fc648330aadbabf20c85fe74